### PR TITLE
DSND-2937: Implement call to acsp-profile-data-api to PUT ACSP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <!--companies house-->
     <structured-logging.version>3.0.17</structured-logging.version>
-    <private-api-sdk-java.version>4.0.215</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.219</private-api-sdk-java.version>
     <kafka-models.version>3.0.8</kafka-models.version>
     <api-helper-java.version>3.0.1</api-helper-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/AcspApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/AcspApiClient.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.acspprofile.consumer.apiclient;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.acspprofile.consumer.logging.DataMapHolder;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+
+@Component
+public class AcspApiClient implements ApiClient {
+
+    private static final String REQUEST_URI = "/authorised-corporate-service-providers/%s/internal";
+
+    private final InternalApiClientFactory internalApiClientFactory;
+    private final ResponseHandler responseHandler;
+
+    public AcspApiClient(InternalApiClientFactory internalApiClientFactory, ResponseHandler responseHandler) {
+        this.internalApiClientFactory = internalApiClientFactory;
+        this.responseHandler = responseHandler;
+    }
+
+    @Override
+    public void putAcspProfile(String acspNumber, InternalAcspApi requestBody) {
+        InternalApiClient client = internalApiClientFactory.get();
+        client.getHttpClient().setRequestId(DataMapHolder.getRequestId());
+
+        final String formattedUri = REQUEST_URI.formatted(acspNumber);
+        try {
+            client.privateDeltaResourceHandler()
+                    .putAcspProfile(formattedUri, requestBody)
+                    .execute();
+        } catch (ApiErrorResponseException ex) {
+            responseHandler.handle(ex);
+        } catch (URIValidationException ex) {
+            responseHandler.handle(ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/ApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/ApiClient.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.acspprofile.consumer.apiclient;
+
+import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
+
+public interface ApiClient {
+
+    void putAcspProfile(String acspNumber, InternalAcspApi requestBody);
+}

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/InternalApiClientFactory.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/InternalApiClientFactory.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.acspprofile.consumer.apiclient;
+
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
+
+@Component
+public class InternalApiClientFactory implements Supplier<InternalApiClient> {
+
+    private final String apiKey;
+    private final String apiUrl;
+
+    public InternalApiClientFactory(@Value("${api.api-key}") String apiKey, @Value("${api.api-url}") String apiUrl) {
+        this.apiKey = apiKey;
+        this.apiUrl = apiUrl;
+    }
+
+    @Override
+    public InternalApiClient get() {
+        InternalApiClient internalApiClient = new InternalApiClient(new ApiKeyHttpClient(apiKey));
+        internalApiClient.setBasePath(apiUrl);
+        return internalApiClient;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaService.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaService.java
@@ -1,25 +1,44 @@
 package uk.gov.companieshouse.acspprofile.consumer.service;
 
+import static uk.gov.companieshouse.acspprofile.consumer.Application.NAMESPACE;
+
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.acspprofile.consumer.apiclient.ApiClient;
+import uk.gov.companieshouse.acspprofile.consumer.logging.DataMapHolder;
 import uk.gov.companieshouse.acspprofile.consumer.mapper.InternalAcspApiMapper;
 import uk.gov.companieshouse.acspprofile.consumer.serdes.AcspProfileDeltaDeserialiser;
+import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
 import uk.gov.companieshouse.api.delta.AcspProfileDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class UpsertDeltaService implements DeltaService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
+
     private final AcspProfileDeltaDeserialiser deltaDeserialiser;
     private final InternalAcspApiMapper mapper;
+    private final ApiClient acspApiClient;
 
-    public UpsertDeltaService(AcspProfileDeltaDeserialiser deltaDeserialiser, InternalAcspApiMapper mapper) {
+    public UpsertDeltaService(AcspProfileDeltaDeserialiser deltaDeserialiser, InternalAcspApiMapper mapper,
+            ApiClient acspApiClient) {
         this.deltaDeserialiser = deltaDeserialiser;
         this.mapper = mapper;
+        this.acspApiClient = acspApiClient;
     }
 
     @Override
     public void process(ChsDelta delta) {
         AcspProfileDelta acspProfileDelta = deltaDeserialiser.deserialiseAcspProfileDelta(delta.getData());
-        mapper.map(acspProfileDelta, delta.getContextId());
+
+        String acspNumber = acspProfileDelta.getAcspNumber();
+        DataMapHolder.get().acspNumber(acspNumber);
+
+        InternalAcspApi requestBody = mapper.map(acspProfileDelta, delta.getContextId());
+        acspApiClient.putAcspProfile(acspNumber, requestBody);
+
+        LOGGER.info("Successfully called PUT ACSP profile", DataMapHolder.getLogMap());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaService.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.acspprofile.consumer.service;
 
-import static uk.gov.companieshouse.acspprofile.consumer.Application.NAMESPACE;
-
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.acspprofile.consumer.apiclient.ApiClient;
 import uk.gov.companieshouse.acspprofile.consumer.logging.DataMapHolder;
@@ -10,13 +8,9 @@ import uk.gov.companieshouse.acspprofile.consumer.serdes.AcspProfileDeltaDeseria
 import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
 import uk.gov.companieshouse.api.delta.AcspProfileDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class UpsertDeltaService implements DeltaService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
     private final AcspProfileDeltaDeserialiser deltaDeserialiser;
     private final InternalAcspApiMapper mapper;
@@ -38,7 +32,5 @@ public class UpsertDeltaService implements DeltaService {
 
         InternalAcspApi requestBody = mapper.map(acspProfileDelta, delta.getContextId());
         acspApiClient.putAcspProfile(acspNumber, requestBody);
-
-        LOGGER.info("Successfully called PUT ACSP profile", DataMapHolder.getLogMap());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,6 @@ management.endpoint.health.show-details=never
 management.endpoint.health.enabled=true
 
 api.api-key=${ACSP_PROFILE_API_KEY:testkey}
-api.api-url=${API_LOCAL_URL:http://localhost:8888}
+api.api-url=${API_LOCAL_URL:http://localhost:8099}
 
 server.port=${PORT:8081}

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/AcspApiClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/AcspApiClientTest.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.acspprofile.consumer.apiclient;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.acspprofile.consumer.logging.DataMapHolder;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.delta.PrivateDeltaResourceHandler;
+import uk.gov.companieshouse.api.handler.delta.acspprofile.request.PrivateAcspProfilePut;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.http.HttpClient;
+
+@ExtendWith(MockitoExtension.class)
+class AcspApiClientTest {
+
+    private static final String ACSP_NUMBER = "AP123456";
+    private static final String REQUEST_URI = "/authorised-corporate-service-providers/%s/internal"
+            .formatted(ACSP_NUMBER);
+    private static final String CONTEXT_ID = "context_id";
+
+    @InjectMocks
+    private AcspApiClient acspApiClient;
+
+    @Mock
+    private InternalApiClientFactory internalApiClientFactory;
+    @Mock
+    private ResponseHandler responseHandler;
+
+    @Mock
+    private InternalAcspApi requestBody;
+    @Mock
+    private InternalApiClient internalApiClient;
+    @Mock
+    private HttpClient apiClient;
+    @Mock
+    private PrivateDeltaResourceHandler privateDeltaResourceHandler;
+    @Mock
+    private PrivateAcspProfilePut privateAcspProfilePut;
+
+    @BeforeEach
+    void whenApiClientStubbing() {
+        when(internalApiClientFactory.get()).thenReturn(internalApiClient);
+        when(internalApiClient.getHttpClient()).thenReturn(apiClient);
+        when(internalApiClient.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
+        when(privateDeltaResourceHandler.putAcspProfile(any(), any())).thenReturn(privateAcspProfilePut);
+    }
+
+    @AfterEach
+    void verifyApiClientCalls() throws ApiErrorResponseException, URIValidationException {
+        verify(apiClient).setRequestId(CONTEXT_ID);
+        verify(internalApiClient).privateDeltaResourceHandler();
+        verify(privateDeltaResourceHandler).putAcspProfile(REQUEST_URI, requestBody);
+        verify(privateAcspProfilePut).execute();
+    }
+
+    @Test
+    void shouldSendSuccessfulPutRequest() {
+        // given
+        DataMapHolder.get().requestId(CONTEXT_ID);
+
+        // when
+        acspApiClient.putAcspProfile(ACSP_NUMBER, requestBody);
+
+        // then
+        verifyNoInteractions(responseHandler);
+    }
+
+    @Test
+    void shouldHandleApiErrorExceptionWhenSendingPutRequest() throws Exception {
+        // given
+        Class<ApiErrorResponseException> exceptionClass = ApiErrorResponseException.class;
+
+        when(privateAcspProfilePut.execute()).thenThrow(exceptionClass);
+
+        DataMapHolder.get().requestId(CONTEXT_ID);
+
+        // when
+        acspApiClient.putAcspProfile(ACSP_NUMBER, requestBody);
+
+        // then
+        verify(responseHandler).handle(any(exceptionClass));
+    }
+
+    @Test
+    void shouldHandleURIValidationExceptionWhenSendingPutRequest() throws Exception {
+        // given
+        Class<URIValidationException> exceptionClass = URIValidationException.class;
+
+        when(privateAcspProfilePut.execute()).thenThrow(exceptionClass);
+
+        DataMapHolder.get().requestId(CONTEXT_ID);
+
+        // when
+        acspApiClient.putAcspProfile(ACSP_NUMBER, requestBody);
+
+        // then
+        verify(responseHandler).handle(any(exceptionClass));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/InternalApiClientFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/apiclient/InternalApiClientFactoryTest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.acspprofile.consumer.apiclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.InternalApiClient;
+
+class InternalApiClientFactoryTest {
+
+    private static final String API_KEY = "api key";
+    private static final String API_URL = "url";
+
+    private final InternalApiClientFactory factory = new InternalApiClientFactory(API_KEY, API_URL);
+
+    @Test
+    void shouldReturnNewInternalApiClient() {
+        // given
+
+        // when
+        InternalApiClient actual = factory.get();
+
+        // then
+        assertEquals(API_URL, actual.getBasePath());
+        assertNotNull(actual.getHttpClient());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/kafka/ConsumerPositiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/kafka/ConsumerPositiveIT.java
@@ -1,19 +1,29 @@
 package uk.gov.companieshouse.acspprofile.consumer.kafka;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.acspprofile.consumer.kafka.KafkaUtils.ERROR_TOPIC;
 import static uk.gov.companieshouse.acspprofile.consumer.kafka.KafkaUtils.INVALID_TOPIC;
 import static uk.gov.companieshouse.acspprofile.consumer.kafka.KafkaUtils.MAIN_TOPIC;
 import static uk.gov.companieshouse.acspprofile.consumer.kafka.KafkaUtils.RETRY_TOPIC;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.commons.io.IOUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -22,12 +32,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import uk.gov.companieshouse.acspprofile.consumer.mapper.EtagGenerator;
 import uk.gov.companieshouse.delta.ChsDelta;
 
 @SpringBootTest
+@WireMockTest(httpPort = 8099)
 class ConsumerPositiveIT extends AbstractKafkaIT {
 
     @Autowired
@@ -36,6 +49,9 @@ class ConsumerPositiveIT extends AbstractKafkaIT {
     private KafkaProducer<String, byte[]> testProducer;
     @Autowired
     private TestConsumerAspect testConsumerAspect;
+
+    @MockBean
+    private EtagGenerator etagGenerator;
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry registry) {
@@ -49,12 +65,21 @@ class ConsumerPositiveIT extends AbstractKafkaIT {
     }
 
     @Test
-    void shouldConsumeAcspProfileDeltaTopicAndProcessTM01Delta() throws Exception {
+    void shouldConsumeAcspProfileDeltaTopicAndSuccessfullySendPutRequest() throws Exception {
         // given
+        final String delta = IOUtils.resourceToString("/acsp-profile-delta.json", StandardCharsets.UTF_8);
+
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
         DatumWriter<ChsDelta> writer = new ReflectDatumWriter<>(ChsDelta.class);
-        writer.write(new ChsDelta("{}", 0, "context_id", false), encoder);
+        writer.write(new ChsDelta(delta, 0, "context_id", false), encoder);
+
+        final String expectedRequestUri = "/authorised-corporate-service-providers/AP123456/internal";
+        stubFor(put(urlEqualTo(expectedRequestUri))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        when(etagGenerator.generateEtag()).thenReturn("generated_etag");
 
         // when
         testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(),
@@ -69,5 +94,9 @@ class ConsumerPositiveIT extends AbstractKafkaIT {
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
+
+        final String expectedRequestBody = IOUtils.resourceToString("/acsp-profile-request-body.json",
+                StandardCharsets.UTF_8);
+        verify(requestMadeFor(new PutRequestMatcher(expectedRequestUri, expectedRequestBody)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/kafka/PutRequestMatcher.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/kafka/PutRequestMatcher.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.acspprofile.consumer.kafka;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
+
+public class PutRequestMatcher implements ValueMatcher<Request> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .setSerializationInclusion(Include.NON_EMPTY)
+            .registerModule(new JavaTimeModule());
+
+    private final String expectedUrl;
+    private final String expectedBody;
+
+    public PutRequestMatcher(String expectedUrl, String expectedBody) {
+        this.expectedUrl = expectedUrl;
+        this.expectedBody = expectedBody;
+    }
+
+    @Override
+    public MatchResult match(Request value) {
+        return MatchResult.aggregate(
+                matchUrl(value.getUrl()),
+                matchMethod(value.getMethod()),
+                matchBody(value.getBodyAsString()));
+    }
+
+    private MatchResult matchUrl(String actualUrl) {
+        return MatchResult.of(expectedUrl.equals(actualUrl));
+    }
+
+    private MatchResult matchMethod(RequestMethod actualMethod) {
+        return MatchResult.of(RequestMethod.PUT.equals(actualMethod));
+    }
+
+    private MatchResult matchBody(String actualBody) {
+        try {
+            InternalAcspApi expected = objectMapper.readValue(expectedBody, InternalAcspApi.class);
+            InternalAcspApi actual = objectMapper.readValue(actualBody, InternalAcspApi.class);
+
+            MatchResult result = MatchResult.of(expected.equals(actual));
+            if (!result.isExactMatch()) {
+                System.out.printf("%nExpected: [%s]%n", expected);
+                System.out.printf("%nActual: [%s]", actual);
+            }
+            return result;
+        } catch (JsonProcessingException ex) {
+            return MatchResult.of(false);
+        }
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/service/UpsertDeltaServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.acspprofile.consumer.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -10,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.acspprofile.consumer.apiclient.AcspApiClient;
 import uk.gov.companieshouse.acspprofile.consumer.mapper.InternalAcspApiMapper;
 import uk.gov.companieshouse.acspprofile.consumer.serdes.AcspProfileDeltaDeserialiser;
 import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
@@ -21,6 +21,7 @@ class UpsertDeltaServiceTest {
 
     private static final String DELTA_DATA = "acsp profile delta data";
     private static final String CONTEXT_ID = "context_id";
+    private static final String ACSP_NUMBER = "AP123456";
 
     @InjectMocks
     private UpsertDeltaService upsertDeltaService;
@@ -28,11 +29,13 @@ class UpsertDeltaServiceTest {
     private AcspProfileDeltaDeserialiser deltaDeserialiser;
     @Mock
     private InternalAcspApiMapper mapper;
+    @Mock
+    private AcspApiClient apiClient;
 
     @Mock
     private AcspProfileDelta acspProfileDelta;
     @Mock
-    private InternalAcspApi internalAcspApi;
+    private InternalAcspApi requestBody;
 
     @Test
     void shouldProcessDelta() {
@@ -40,7 +43,8 @@ class UpsertDeltaServiceTest {
         ChsDelta delta = new ChsDelta(DELTA_DATA, 0, CONTEXT_ID, false);
 
         when(deltaDeserialiser.deserialiseAcspProfileDelta(any())).thenReturn(acspProfileDelta);
-        when(mapper.map(any(), any())).thenReturn(internalAcspApi);
+        when(mapper.map(any(), any())).thenReturn(requestBody);
+        when(acspProfileDelta.getAcspNumber()).thenReturn(ACSP_NUMBER);
 
         // when
         upsertDeltaService.process(delta);
@@ -48,6 +52,6 @@ class UpsertDeltaServiceTest {
         // then
         verify(deltaDeserialiser).deserialiseAcspProfileDelta(DELTA_DATA);
         verify(mapper).map(acspProfileDelta, CONTEXT_ID);
-        verifyNoInteractions(internalAcspApi);
+        verify(apiClient).putAcspProfile(ACSP_NUMBER, requestBody);
     }
 }

--- a/src/test/resources/acsp-profile-request-body.json
+++ b/src/test/resources/acsp-profile-request-body.json
@@ -7,8 +7,19 @@
     "business_sector": "high-value-dealers",
     "notified_from": "2024-09-02",
     "deauthorised_from": "2025-01-08",
-    "etag": "<etag>",
+    "etag": "generated_etag",
     "registered_office_address": {
+      "address_line_1": "456 Another Street",
+      "address_line_2": "Floor 2",
+      "care_of": "Jane Smith",
+      "country": "united-kingdom",
+      "locality": "Manchester",
+      "po_box": "PO Box 123",
+      "postal_code": "M1 2AB",
+      "premises": "Another Building",
+      "region": "Greater Manchester"
+    },
+    "service_address": {
       "address_line_1": "456 Another Street",
       "address_line_2": "Floor 2",
       "care_of": "Jane Smith",


### PR DESCRIPTION
## Describe the changes
* Takes the transformed request body and sends it to the PUT endpoint in acsp-profile-data-api.
* Includes a kafka/wiremock integration test.

### Related Jira tickets
[DSND-2937](https://companieshouse.atlassian.net/browse/DSND-2937)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2937]: https://companieshouse.atlassian.net/browse/DSND-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ