### PR TITLE
DSND-3137: Correct scaling cooldown config to delay scale out instead of scale in

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -29,36 +29,37 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
-  batch_service           = true
+  batch_service = true
 
   # ECS Task container health check
   use_task_container_healthcheck = true
   healthcheck_path               = local.healthcheck_path
-  healthcheck_matcher            = local.healthcheck_matcher
+  healthcheck_matcher = local.healthcheck_matcher
 
   # Docker container details
   docker_registry   = var.docker_registry
   docker_repo       = local.docker_repo
   container_version = var.acsp_profile_delta_consumer_version
-  container_port    = local.container_port
+  container_port = local.container_port
 
   # Service configuration
   service_name = local.service_name
-  name_prefix  = local.name_prefix
+  name_prefix = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count                  = var.desired_task_count
-  max_task_count                      = var.max_task_count
-  required_cpus                       = var.required_cpus
-  required_memory                     = var.required_memory
-  service_autoscale_enabled           = var.service_autoscale_enabled
-  service_autoscale_target_value_cpu  = var.service_autoscale_target_value_cpu
-  service_autoscale_scale_in_cooldown = var.service_autoscale_scale_in_cooldown
-  service_scaledown_schedule          = var.service_scaledown_schedule
-  service_scaleup_schedule            = var.service_scaleup_schedule
-  use_capacity_provider               = var.use_capacity_provider
-  use_fargate                         = var.use_fargate
-  fargate_subnets                     = local.application_subnet_ids
+  desired_task_count                   = var.desired_task_count
+  max_task_count                       = var.max_task_count
+  required_cpus                        = var.required_cpus
+  required_memory                      = var.required_memory
+  service_autoscale_enabled            = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
+  service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
+  service_scaledown_schedule           = var.service_scaledown_schedule
+  service_scaleup_schedule             = var.service_scaleup_schedule
+  use_capacity_provider                = var.use_capacity_provider
+  use_fargate                          = var.use_fargate
+  fargate_subnets = local.application_subnet_ids
 
   # Service environment variable and secret configs
   task_environment          = local.task_environment
@@ -73,5 +74,5 @@ module "secrets" {
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
-  secrets     = nonsensitive(local.service_secrets)
+  secrets = nonsensitive(local.service_secrets)
 }

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -7,4 +7,9 @@ log_level = "trace"
 
 required_cpus = 512
 required_memory = 1024
-service_autoscale_scale_in_cooldown = 600
+service_autoscale_scale_out_cooldown = 600
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,8 +3,8 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-log_level = "trace"
+log_level = "info"
 
 required_cpus = 512
 required_memory = 1024
-service_autoscale_scale_in_cooldown = 600
+service_autoscale_scale_out_cooldown = 600

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -3,13 +3,13 @@ aws_profile = "staging-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-log_level = "trace"
+log_level = "info"
+
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600
 
 # Scheduled scaling of tasks
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
-
-required_cpus = 512
-required_memory = 1024
-service_autoscale_scale_in_cooldown = 600

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -71,7 +71,12 @@ variable "service_autoscale_target_value_cpu" {
 }
 variable "service_autoscale_scale_in_cooldown" {
   type        = number
-  description = "Cooldown in seconds for ECS Service scale in"
+  description = "Cooldown in seconds for ECS Service scale in (run fewer tasks)"
+  default     = 300
+}
+variable "service_autoscale_scale_out_cooldown" {
+  type        = number
+  description = "Cooldown in seconds for ECS Service scale out (add more tasks)"
   default     = 300
 }
 variable "service_scaledown_schedule" {


### PR DESCRIPTION
## Describe the changes
* Unset scale in cooldown which is the length of time to wait before reducing the number of running tasks.
* Increase scale out cooldown which is the length of time to wait before increasing the number of running tasks.
* This prevents autoscaling from kicking in during service deployment which can cause the service to reach an unhealthy state.
[See link for info](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html#:~:text=Amazon%20ECS%20publishes,of%20low%20utilization.)

### Related Jira tickets
[DSND-3137](https://companieshouse.atlassian.net/browse/DSND-3137)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the code been double-checked against `main`?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Is the `README` up to date?
- [ ] Does the code adhere to standards in this repository, including SonarQube checks?
- [ ] Has the Jira ticket been updated with any relevant comments?

### Configuration
_Where required, add links to the respective pull requests_
- [ ] Are any configuration changes required in `docker-chs-development`?
- [ ] Have new env vars been added to `ecs-service-configs-dev`?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests locally?
- [ ] Have mandatory manual test cases been run?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-3137]: https://companieshouse.atlassian.net/browse/DSND-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ