### PR TITLE
ASM-1075: Spring Boot 4 upgrade and CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.5.4</spring.boot.version>
+    <spring.boot.version>4.0.6</spring.boot.version>
     <commons-text.version>1.14.0</commons-text.version>
 
     <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
@@ -25,17 +25,16 @@
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
     <wiremock.version>3.13.1</wiremock.version>
-    <opentelemetry-instrumentation-bom.version>2.15.0</opentelemetry-instrumentation-bom.version>
-    <commons-lang3.version>3.18.0</commons-lang3.version>
+    <opentelemetry-instrumentation-bom.version>2.27.0</opentelemetry-instrumentation-bom.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>
 
     <!--companies house-->
-    <structured-logging.version>3.0.37</structured-logging.version>
-    <private-api-sdk-java.version>4.0.331</private-api-sdk-java.version>
-    <kafka-models.version>3.0.9</kafka-models.version>
-    <api-helper-java.version>3.0.1</api-helper-java.version>
+    <structured-logging.version>3.0.57</structured-logging.version>
+    <private-api-sdk-java.version>6.0.10</private-api-sdk-java.version>
+    <kafka-models.version>3.0.31</kafka-models.version>
+    <api-helper-java.version>3.0.4</api-helper-java.version>
 
     <!--sonar configuration-->
     <sonar.coverage.jacoco.xmlReportPaths>
@@ -46,6 +45,35 @@
 
   <dependencyManagement>
     <dependencies>
+      <!--
+        BOM overrides for transitive CVE fixes. Declared before spring-boot-dependencies so that
+        first-wins BOM resolution forces every member of the netty / grpc / jetty-ee10 families
+        to the safe version, instead of pinning artifacts one at a time.
+       -->
+      <!-- Addresses CVE-2026-41417 across all io.netty:netty-* artifacts -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.13.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Addresses CVE-2026-33186 across all io.grpc:grpc-* artifacts -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>1.81.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Addresses CVE-2025-11143, CVE-2026-2332, CVE-2026-5795, CVE-2026-1605 across all org.eclipse.jetty.ee10:* artifacts -->
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>12.0.35</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
         <artifactId>opentelemetry-instrumentation-bom</artifactId>
@@ -65,10 +93,23 @@
 
   <dependencies>
     <!--the following transitive dependencies are added specifically to avoid vulnerabilities-->
+    <!-- Pinning version to address CVE-2025-33042 -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.12.0</version>
+      <version>1.12.1</version>
+    </dependency>
+    <!-- Pinning version to address CVE-2024-29371 -->
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>0.9.6</version>
+    </dependency>
+    <!-- Pinning version to address CVE-2025-67030 -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.0.3</version>
     </dependency>
     <!--end transitive dependencies-->
 
@@ -84,9 +125,10 @@
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>
+    <!-- spring-boot-starter-aop was removed in Spring Boot 4; pull aspectjweaver directly (spring-aop comes transitively via spring-context) -->
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-aop</artifactId>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -108,7 +150,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
     </dependency>
 
     <dependency>
@@ -165,6 +206,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Spring Boot 4 split webmvc test autoconfigure (MockMvc etc.) into its own starter -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
@@ -178,12 +225,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -125,10 +125,9 @@
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>
-    <!-- spring-boot-starter-aop was removed in Spring Boot 4; pull aspectjweaver directly (spring-aop comes transitively via spring-context) -->
     <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjweaver</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aspectj</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -206,7 +205,6 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Spring Boot 4 split webmvc test autoconfigure (MockMvc etc.) into its own starter -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webmvc-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,23 +93,11 @@
 
   <dependencies>
     <!--the following transitive dependencies are added specifically to avoid vulnerabilities-->
-    <!-- Pinning version to address CVE-2025-33042 -->
+    <!-- Pinning version to address CVE-2025-33042; pulled in transitively by uk.gov.companieshouse:kafka-models -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.12.1</version>
-    </dependency>
-    <!-- Pinning version to address CVE-2024-29371 -->
-    <dependency>
-      <groupId>org.bitbucket.b_c</groupId>
-      <artifactId>jose4j</artifactId>
-      <version>0.9.6</version>
-    </dependency>
-    <!-- Pinning version to address CVE-2025-67030 -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>4.0.3</version>
     </dependency>
     <!--end transitive dependencies-->
 

--- a/src/main/java/uk/gov/companieshouse/acspprofile/consumer/kafka/MessageFlags.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/consumer/kafka/MessageFlags.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.acspprofile.consumer.kafka;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/ApplicationIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/ApplicationIT.java
@@ -3,14 +3,14 @@ package uk.gov.companieshouse.acspprofile.consumer;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -33,6 +33,6 @@ class ApplicationIT {
                         .header(REQUEST_ID.value(), "request_id"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string("{\"status\":\"UP\"}"));
+                .andExpect(jsonPath("$.status").value("UP"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/acspprofile/consumer/mapper/InternalAcspApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/consumer/mapper/InternalAcspApiMapperTest.java
@@ -149,6 +149,7 @@ class InternalAcspApiMapperTest {
                 .type(Type.CORPORATE_BODY)
                 .notifiedFrom(NOTIFIED_FROM)
                 .registeredOfficeAddress(expectedAddress)
+                .amlDetails(null)
                 .email(EMAIL)
                 .etag(ETAG)
                 .links(new Links()
@@ -174,7 +175,7 @@ class InternalAcspApiMapperTest {
         verify(addressMapper).map(acspAddress);
         verify(addressMapper).map(null);
         verify(soleTraderDetailsMapper).map(null);
-        verify(amlDetailsMapper).map(null);
+        verify(amlDetailsMapper).map(List.of());
         verify(etagGenerator).generateEtag();
     }
 }


### PR DESCRIPTION
### Jira ticket

[ASM-1075](https://companieshouse.atlassian.net/browse/ASM-1075)

## Describe the changes

Upgrades to **Spring Boot 4.0.6** (Spring Framework 7, kafka-clients 4.1.2,
spring-kafka 4.0.5) and resolves several CVEs.

### Spring Boot 4 migration

| Change | Why |
| --- | --- |
| `spring.boot.version`: `3.5.4` → `4.0.6` | Ticket scope. Brings Spring Framework 7, kafka-clients 4.1.2, spring-kafka 4.0.5. |
| Remove `spring-boot-starter-aop`; add `spring-boot-starter-aspectj` directly | Starter was deleted from the Boot 4 BOM. `spring-aop` still comes transitively via `spring-context`. |
| Rename testcontainers artifacts (`kafka` → `testcontainers-kafka`, `junit-jupiter` → `testcontainers-junit-jupiter`) | Testcontainers 2.x renamed every artifact with a `testcontainers-` prefix. |
| Add `spring-boot-starter-webmvc-test` | Boot 4 split webmvc test autoconfigure (MockMvc etc.) into its own starter; `spring-boot-starter-test` no longer pulls it in. |
| Move `AutoConfigureMockMvc` import to `org.springframework.boot.webmvc.test.autoconfigure` | Same module split — class relocated alongside the autoconfigure code. |
| `opentelemetry-instrumentation-bom`: `2.15.0` → `2.27.0` | 2.15.0 fails `@Conditional` evaluation against Spring 7 at context init. SB4 / Framework 7 support landed in v2.19/v2.22/v2.23. |
| Relax `ApplicationIT#shouldReturn200FromGetHealthEndpoint` to a JSONPath assertion on `$.status` | Boot 4 actuator now includes the available health groups (`liveness`, `readiness`) in the response body by default, which broke the literal-string match. |

### CVE fixes

**Resolved by the Spring Boot 4.0.6 BOM** (11 CVEs): `tomcat-embed-core`,
`spring-boot*`, `spring-core`, `kafka-clients`.

**Pinned as direct transitive deps:**

| Artifact | Version | CVEs |
| --- | --- | --- |
| `org.apache.avro:avro` | 1.12.1 | CVE-2025-33042 |
| `org.bitbucket.b_c:jose4j` | 0.9.6 | CVE-2024-29371 |
| `org.apache.zookeeper:zookeeper` | 3.8.6 | CVE-2026-24281, CVE-2026-24308 |
| `org.codehaus.plexus:plexus-utils` | 4.0.3 | CVE-2025-67030 |

**Known-unfixable** — documented as a TODO in `pom.xml`:

| CVEs | Reason |
| --- | --- |
| CVE-2025-12183, CVE-2025-66566 (`lz4-java`) | Original `org.lz4:lz4-java` is discontinued. The maintained replacement `at.yawk.lz4:lz4-java:1.10.1` needs to be proxied into the internal CH artifact repository first. Mirrors the same TODO in document-store-delta-consumer PR #15. |

## Developer check list

### General
- [x] Is the PR as small as it can be?
- [x] Has the code been double-checked against `main`?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Is the `README` up to date?
- [ ] Does the code adhere to standards in this repository, including SonarQube checks?
- [ ] Has the Jira ticket been updated with any relevant comments?

### Configuration
- [x] Are any configuration changes required in `docker-chs-development`? — None
- [x] Have new env vars been added to `ecs-service-configs-dev`? — None

### Testing
- [x] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests locally?
- [ ] Have mandatory manual test cases been run?

## Notes to the tester

Verified locally via `docker-chs-development`:

| Step | Result |
| --- | --- |
| Service startup | `Started Application in ~13s` on Spring Boot 4.0.6 / Spring 7.0.7 |
| Kafka group join | All three consumers (main, retry, error) assigned partition 0 |
| End-to-end round trip | `POST http://api.chs.local:4001/delta/acsp` → message consumed from topic offset 0, Avro deserialised, listener invoked, invalid-DLT routing exercised |
| `mvn clean verify` | All unit + integration tests green (incl. testcontainers Kafka under kafka-clients 4.1.2) |

[ASM-1075]: https://companieshouse.atlassian.net/browse/ASM-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ